### PR TITLE
corrigé problème historique

### DIFF
--- a/app/views/sub_categories/show.html.erb
+++ b/app/views/sub_categories/show.html.erb
@@ -36,7 +36,7 @@
           <% @articles.each_slice(3) do |article_group| %>
           <div class="section-row">
               <% article_group.each do |article| %>
-                  <%= link_to article_path(article), class: "subcategory-card-link" do %>
+                  <%= link_to article_path(article), class: "subcategory-card-link", data: {turbo_prefetch: false} do %>
                     <%= render "article_card", article: article%>
                   <% end %>
               <% end %>


### PR DESCRIPTION
L'historique affiche bien uniquement le lien qui a été cliqué et pas les liens qui ont été survolé avec la souris 